### PR TITLE
Ignore unit tests on GH action

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,4 +1,4 @@
-on: [push]
+on: [push, pull_request]
 
 name: miri
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,8 +62,8 @@ fn supports_color(stream: Stream) -> usize {
     } else if std::env::var("COLORTERM").is_ok()
         || std::env::var("TERM").map(|term| check_ansi_color(&term)) == Ok(true)
         || std::env::consts::OS == "windows"
-        || is_ci::uncached()
         || std::env::var("CLICOLOR").map_or(false, |v| v != "0")
+        || is_ci::uncached()
     {
         1
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ fn supports_color(stream: Stream) -> usize {
         || std::env::var("TERM").map(|term| check_ansi_color(&term)) == Ok(true)
         || std::env::consts::OS == "windows"
         || is_ci::uncached()
-        || std::env::var("CLICOLOR") != Ok("0".into())
+        || std::env::var("CLICOLOR").map_or(false, |v| v != "0")
     {
         1
     } else {
@@ -157,6 +157,7 @@ mod tests {
     }
 
     #[test]
+		#[cfg_attr(miri, ignore)]
     fn test_clicolor_ansi() {
         set_up();
 
@@ -170,15 +171,16 @@ mod tests {
         assert_eq!(on(atty::Stream::Stdout), expected);
 
         std::env::set_var("CLICOLOR", "0");
-        assert_eq!(on(atty::Stream::Stderr), None);
+        assert_eq!(on(atty::Stream::Stdout), None);
     }
 
     #[test]
+		#[cfg_attr(miri, ignore)]
     fn test_clicolor_force_ansi() {
         set_up();
 
         std::env::set_var("CLICOLOR", "0");
-        std::env::set_var("CLICOLOR_FOCE", "1");
+        std::env::set_var("CLICOLOR_FORCE", "1");
         let expected = Some(ColorLevel {
             level: 1,
             has_basic: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,15 @@ mod tests {
     }
 
     #[test]
-		#[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)]
+    fn test_empty_env() {
+        set_up();
+
+        assert_eq!(on(atty::Stream::Stdout), None);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_clicolor_ansi() {
         set_up();
 
@@ -175,7 +183,7 @@ mod tests {
     }
 
     #[test]
-		#[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)]
     fn test_clicolor_force_ansi() {
         set_up();
 


### PR DESCRIPTION
I just realized that the unit-tests is much trickier than it looks.

1. GH action does not play nice with `atty::is`. Unit-tests couldn't be run in CI reliably.
2. Cargo run tests in parallel by default, and this affects reliability of the unit-test. Unit-test should be run with `cargo test -- --test-threads=1`. Mght want to put this information somewhere. Another option is to remove unit-test altogether.