### PR TITLE
Replace atty with is_terminal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atty = "0.2.14"
+is-terminal = "0.4.0"
 is_ci = "1.1.1"


### PR DESCRIPTION
Fixes https://github.com/zkat/supports-color/issues/9