### PR TITLE
Replace `is-terminal` with `std::io::IsTerminal`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ documentation = "https://docs.rs/supports-color"
 license = "Apache-2.0"
 readme = "README.md"
 edition = "2018"
+rust-version = "1.70.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-is-terminal = "0.4.0"
 is_ci = "1.1.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ fn translate_level(level: usize) -> Option<ColorLevel> {
 }
 
 fn is_a_tty(stream: Stream) -> bool {
-    use is_terminal::*;
+    use std::io::IsTerminal;
     match stream {
         Stream::Stdout => std::io::stdout().is_terminal(),
         Stream::Stderr => std::io::stderr().is_terminal(),


### PR DESCRIPTION
This removes the `is-terminal` dependency but raises MSRV to 1.70.0.