### PR TITLE
Allow the is_terminal check to be overridden by environment variable.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,10 @@ fn supports_color(stream: Stream) -> usize {
     let force_color = env_force_color();
     if force_color > 0 {
         force_color
-    } else if env_no_color() || as_str(&env::var("TERM")) == Ok("dumb") || !is_a_tty(stream) {
+    } else if env_no_color()
+        || as_str(&env::var("TERM")) == Ok("dumb")
+        || !(is_a_tty(stream) || env::var("IGNORE_IS_TERMINAL").map_or(false, |v| v != "0"))
+    {
         0
     } else if as_str(&env::var("COLORTERM")) == Ok("truecolor")
         || as_str(&env::var("TERM_PROGRAM")) == Ok("iTerm.app")
@@ -218,6 +221,7 @@ mod tests {
         let _test_guard = TEST_LOCK.lock().unwrap();
         set_up();
 
+        env::set_var("IGNORE_IS_TERMINAL", "1");
         env::set_var("CLICOLOR", "1");
         let expected = Some(ColorLevel {
             level: 1,


### PR DESCRIPTION
Currently the tests fail in environments where the output is written to something other than a TTY or a known CI environment. This is because the code makes a hard-coded call to `is_terminal` and disables colour output if that returns false.

This change introduces an environment variable `IGNORE_IS_TERMINAL` which overrides the `is_terminal` check. The tests which depend on colour output now set this environment variable so that they pass in such environments.

Fixes #12